### PR TITLE
remove star selector

### DIFF
--- a/css/imagehover.css
+++ b/css/imagehover.css
@@ -7,8 +7,8 @@
  * http://www.opensource.org/licenses/mit-license.php
 
  */
-*[class^='imghvr-'],
-*[class*=' imghvr-'] {
+[class^='imghvr-'],
+[class*=' imghvr-'] {
   position: relative;
   display: inline-block;
   margin: 0px;
@@ -22,13 +22,13 @@
   -webkit-transform: translateZ(0);
   transform: translateZ(0);
 }
-*[class^='imghvr-'] > img,
-*[class*=' imghvr-'] > img {
+[class^='imghvr-'] > img,
+[class*=' imghvr-'] > img {
   vertical-align: top;
   max-width: 100%;
 }
-*[class^='imghvr-'] figcaption,
-*[class*=' imghvr-'] figcaption {
+[class^='imghvr-'] figcaption,
+[class*=' imghvr-'] figcaption {
   background-color: inherit;
   padding: 30px;
   position: absolute;
@@ -37,16 +37,16 @@
   left: 0;
   right: 0;
 }
-*[class^='imghvr-'] h3,
-*[class*=' imghvr-'] h3,
-*[class^='imghvr-'] p,
-*[class*=' imghvr-'] p {
+[class^='imghvr-'] h3,
+[class*=' imghvr-'] h3,
+[class^='imghvr-'] p,
+[class*=' imghvr-'] p {
   margin: 0;
   padding: 0;
   color: #fff;
 }
-*[class^='imghvr-'] a,
-*[class*=' imghvr-'] a {
+[class^='imghvr-'] a,
+[class*=' imghvr-'] a {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -54,18 +54,18 @@
   right: 0;
   z-index: 1;
 }
-*[class^='imghvr-'],
-*[class*=' imghvr-'],
-*[class^='imghvr-']:before,
-*[class^='imghvr-']:after,
-*[class*=' imghvr-']:before,
-*[class*=' imghvr-']:after,
-*[class^='imghvr-'] *,
-*[class*=' imghvr-'] *,
-*[class^='imghvr-'] *:before,
-*[class^='imghvr-'] *:after,
-*[class*=' imghvr-'] *:before,
-*[class*=' imghvr-'] *:after {
+[class^='imghvr-'],
+[class*=' imghvr-'],
+[class^='imghvr-']:before,
+[class^='imghvr-']:after,
+[class*=' imghvr-']:before,
+[class*=' imghvr-']:after,
+[class^='imghvr-'] *,
+[class*=' imghvr-'] *,
+[class^='imghvr-'] *:before,
+[class^='imghvr-'] *:after,
+[class*=' imghvr-'] *:before,
+[class*=' imghvr-'] *:after {
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
   -webkit-transition: all 0.35s ease;
@@ -84,10 +84,10 @@
 }
 /* imghvr-push-*, imghvr-slide-*
    ----------------------------- */
-*[class^='imghvr-push-']:hover figcaption,
-*[class*=' imghvr-push-']:hover figcaption,
-*[class^='imghvr-slide-']:hover figcaption,
-*[class*=' imghvr-slide-']:hover figcaption {
+[class^='imghvr-push-']:hover figcaption,
+[class*=' imghvr-push-']:hover figcaption,
+[class^='imghvr-slide-']:hover figcaption,
+[class*=' imghvr-slide-']:hover figcaption {
   -webkit-transform: translate(0, 0);
   transform: translate(0, 0);
 }
@@ -160,8 +160,8 @@
 }
 /* imghvr-reveal-*
    ----------------------------- */
-*[class^='imghvr-reveal-']:before,
-*[class*=' imghvr-reveal-']:before {
+[class^='imghvr-reveal-']:before,
+[class*=' imghvr-reveal-']:before {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -170,17 +170,17 @@
   content: '';
   background-color: inherit;
 }
-*[class^='imghvr-reveal-'] figcaption,
-*[class*=' imghvr-reveal-'] figcaption {
+[class^='imghvr-reveal-'] figcaption,
+[class*=' imghvr-reveal-'] figcaption {
   opacity: 0;
 }
-*[class^='imghvr-reveal-']:hover:before,
-*[class*=' imghvr-reveal-']:hover:before {
+[class^='imghvr-reveal-']:hover:before,
+[class*=' imghvr-reveal-']:hover:before {
   -webkit-transform: translate(0, 0);
   transform: translate(0, 0);
 }
-*[class^='imghvr-reveal-']:hover figcaption,
-*[class*=' imghvr-reveal-']:hover figcaption {
+[class^='imghvr-reveal-']:hover figcaption,
+[class*=' imghvr-reveal-']:hover figcaption {
   opacity: 1;
   -webkit-transition-delay: 0.2s;
   transition-delay: 0.2s;
@@ -211,22 +211,22 @@
 }
 /* imghvr-hinge-*
    ----------------------------- */
-*[class^='imghvr-hinge-'],
-*[class*=' imghvr-hinge-'] {
+[class^='imghvr-hinge-'],
+[class*=' imghvr-hinge-'] {
   -webkit-perspective: 50em;
   perspective: 50em;
 }
-*[class^='imghvr-hinge-'] figcaption,
-*[class*=' imghvr-hinge-'] figcaption {
+[class^='imghvr-hinge-'] figcaption,
+[class*=' imghvr-hinge-'] figcaption {
   opacity: 0;
   z-index: 1;
 }
-*[class^='imghvr-hinge-']:hover img,
-*[class*=' imghvr-hinge-']:hover img {
+[class^='imghvr-hinge-']:hover img,
+[class*=' imghvr-hinge-']:hover img {
   opacity: 0;
 }
-*[class^='imghvr-hinge-']:hover figcaption,
-*[class*=' imghvr-hinge-']:hover figcaption {
+[class^='imghvr-hinge-']:hover figcaption,
+[class*=' imghvr-hinge-']:hover figcaption {
   opacity: 1;
   -webkit-transition-delay: 0.2s;
   transition-delay: 0.2s;
@@ -322,25 +322,25 @@
 }
 /* imghvr-flip-*
    ----------------------------- */
-*[class^='imghvr-flip-'],
-*[class*=' imghvr-flip-'] {
+[class^='imghvr-flip-'],
+[class*=' imghvr-flip-'] {
   -webkit-perspective: 50em;
   perspective: 50em;
 }
-*[class^='imghvr-flip-'] img,
-*[class*=' imghvr-flip-'] img {
+[class^='imghvr-flip-'] img,
+[class*=' imghvr-flip-'] img {
   backface-visibility: hidden;
 }
-*[class^='imghvr-flip-'] figcaption,
-*[class*=' imghvr-flip-'] figcaption {
+[class^='imghvr-flip-'] figcaption,
+[class*=' imghvr-flip-'] figcaption {
   opacity: 0;
 }
-*[class^='imghvr-flip-']:hover > img,
-*[class*=' imghvr-flip-']:hover > img {
+[class^='imghvr-flip-']:hover > img,
+[class*=' imghvr-flip-']:hover > img {
   opacity: 0;
 }
-*[class^='imghvr-flip-']:hover figcaption,
-*[class*=' imghvr-flip-']:hover figcaption {
+[class^='imghvr-flip-']:hover figcaption,
+[class*=' imghvr-flip-']:hover figcaption {
   opacity: 1;
   -webkit-transition-delay: 0.15s;
   transition-delay: 0.15s;
@@ -409,27 +409,27 @@
 }
 /* imghvr-shutter-out-*
    ----------------------------- */
-*[class^='imghvr-shutter-out-']:before,
-*[class*=' imghvr-shutter-out-']:before {
+[class^='imghvr-shutter-out-']:before,
+[class*=' imghvr-shutter-out-']:before {
   background: inherit;
   position: absolute;
   content: '';
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
 }
-*[class^='imghvr-shutter-out-'] figcaption,
-*[class*=' imghvr-shutter-out-'] figcaption {
+[class^='imghvr-shutter-out-'] figcaption,
+[class*=' imghvr-shutter-out-'] figcaption {
   opacity: 0;
   -webkit-transition-delay: 0s;
   transition-delay: 0s;
 }
-*[class^='imghvr-shutter-out-']:hover:before,
-*[class*=' imghvr-shutter-out-']:hover:before {
+[class^='imghvr-shutter-out-']:hover:before,
+[class*=' imghvr-shutter-out-']:hover:before {
   -webkit-transition-delay: 0s;
   transition-delay: 0s;
 }
-*[class^='imghvr-shutter-out-']:hover figcaption,
-*[class*=' imghvr-shutter-out-']:hover figcaption {
+[class^='imghvr-shutter-out-']:hover figcaption,
+[class*=' imghvr-shutter-out-']:hover figcaption {
   opacity: 1;
   -webkit-transition-delay: 0.1s;
   transition-delay: 0.1s;
@@ -488,31 +488,31 @@
 }
 /* imghvr-shutter-in-*
    ----------------------------- */
-*[class^='imghvr-shutter-in-']:after,
-*[class*=' imghvr-shutter-in-']:after,
-*[class^='imghvr-shutter-in-']:before,
-*[class*=' imghvr-shutter-in-']:before {
+[class^='imghvr-shutter-in-']:after,
+[class*=' imghvr-shutter-in-']:after,
+[class^='imghvr-shutter-in-']:before,
+[class*=' imghvr-shutter-in-']:before {
   background: inherit;
   position: absolute;
   content: '';
 }
-*[class^='imghvr-shutter-in-']:after,
-*[class*=' imghvr-shutter-in-']:after {
+[class^='imghvr-shutter-in-']:after,
+[class*=' imghvr-shutter-in-']:after {
   top: 0;
   left: 0;
 }
-*[class^='imghvr-shutter-in-']:before,
-*[class*=' imghvr-shutter-in-']:before {
+[class^='imghvr-shutter-in-']:before,
+[class*=' imghvr-shutter-in-']:before {
   right: 0;
   bottom: 0;
 }
-*[class^='imghvr-shutter-in-'] figcaption,
-*[class*=' imghvr-shutter-in-'] figcaption {
+[class^='imghvr-shutter-in-'] figcaption,
+[class*=' imghvr-shutter-in-'] figcaption {
   opacity: 0;
   z-index: 1;
 }
-*[class^='imghvr-shutter-in-']:hover figcaption,
-*[class*=' imghvr-shutter-in-']:hover figcaption {
+[class^='imghvr-shutter-in-']:hover figcaption,
+[class*=' imghvr-shutter-in-']:hover figcaption {
   opacity: 1;
   -webkit-transition-delay: 0.2s;
   transition-delay: 0.2s;
@@ -613,30 +613,30 @@
 }
 /* imghvr-fold*
    ----------------------------- */
-*[class^='imghvr-fold'],
-*[class*=' imghvr-fold'] {
+[class^='imghvr-fold'],
+[class*=' imghvr-fold'] {
   -webkit-perspective: 50em;
   perspective: 50em;
 }
-*[class^='imghvr-fold'] img,
-*[class*=' imghvr-fold'] img {
+[class^='imghvr-fold'] img,
+[class*=' imghvr-fold'] img {
   -webkit-transform-origin: 50% 0%;
   -ms-transform-origin: 50% 0%;
   transform-origin: 50% 0%;
 }
-*[class^='imghvr-fold'] figcaption,
-*[class*=' imghvr-fold'] figcaption {
+[class^='imghvr-fold'] figcaption,
+[class*=' imghvr-fold'] figcaption {
   z-index: 1;
   opacity: 0;
 }
-*[class^='imghvr-fold']:hover > img,
-*[class*=' imghvr-fold']:hover > img {
+[class^='imghvr-fold']:hover > img,
+[class*=' imghvr-fold']:hover > img {
   opacity: 0;
   -webkit-transition-delay: 0;
   transition-delay: 0;
 }
-*[class^='imghvr-fold']:hover figcaption,
-*[class*=' imghvr-fold']:hover figcaption {
+[class^='imghvr-fold']:hover figcaption,
+[class*=' imghvr-fold']:hover figcaption {
   -webkit-transform: rotateX(0deg) translate3d(0, 0%, 0) scale(1);
   transform: rotateX(0deg) translate3d(0, 0%, 0) scale(1);
   opacity: 1;
@@ -733,8 +733,8 @@
 }
 /* imghvr-zoom-out*
    ----------------------------- */
-*[class^='imghvr-zoom-out'] figcaption,
-*[class*=' imghvr-zoom-out'] figcaption {
+[class^='imghvr-zoom-out'] figcaption,
+[class*=' imghvr-zoom-out'] figcaption {
   -webkit-transform: scale(0.5);
   transform: scale(0.5);
   -webkit-transform-origin: 50% 50%;
@@ -742,10 +742,10 @@
   transform-origin: 50% 50%;
   opacity: 0;
 }
-*[class^='imghvr-zoom-out']:hover figcaption,
-*[class*=' imghvr-zoom-out']:hover figcaption,
-*[class^='imghvr-zoom-out'].hover figcaption,
-*[class*=' imghvr-zoom-out'].hover figcaption {
+[class^='imghvr-zoom-out']:hover figcaption,
+[class*=' imghvr-zoom-out']:hover figcaption,
+[class^='imghvr-zoom-out'].hover figcaption,
+[class*=' imghvr-zoom-out'].hover figcaption {
   -webkit-transform: scale(1);
   transform: scale(1);
   opacity: 1;


### PR DESCRIPTION
CSS attribute selectors do work without the `*` (star) selector.
This will be slightly faster and saves a few extra bytes
