### PR TITLE
Make hover effect possible on mobile

### DIFF
--- a/scss/imagehover.scss
+++ b/scss/imagehover.scss
@@ -61,6 +61,25 @@
   transition: all .35s ease;
 }
 
+// For mobile devices hide the link until effect has executed
+[class^='imghvr-'] {
+  a {
+    visibility: hidden;
+  }
+  &:hover {
+    a {
+      animation: makevisible 0s 0.1s forwards;
+      visibility: hidden;
+    }
+  }
+}
+
+@keyframes makevisible  {
+  to {
+    visibility: visible;
+  }
+}
+
 @import "effects/_imghvr-fade";
 @import "effects/_imghvr-push";
 @import "effects/_imghvr-slide";


### PR DESCRIPTION
On mobile the hover effect is executed immediately after the image is clicked. That wat the text in the figurecaption cannot be read. Showing the link after a small delay will fix this. Hope you'll find this useful!